### PR TITLE
Normalize bearer tokens before storing in session

### DIFF
--- a/src/OrderAuth.php
+++ b/src/OrderAuth.php
@@ -79,12 +79,18 @@ function orderStoreTrueApiToken(string $token, ?int $expiresAt = null): void
         return;
     }
 
+    $normalizedToken = normalizeBearerToken($token);
+    if ($normalizedToken === '') {
+        orderForgetTrueApiToken();
+        return;
+    }
+
     if ($expiresAt === null || $expiresAt <= time()) {
-        $expiresAt = nkGuessTokenExpiration($token);
+        $expiresAt = nkGuessTokenExpiration($normalizedToken);
     }
 
     $_SESSION[ORDER_TRUE_API_TOKEN_SESSION_KEY] = [
-        'token'      => $token,
+        'token'      => $normalizedToken,
         'expires_at' => $expiresAt,
     ];
 }


### PR DESCRIPTION
## Summary
- trim possible Bearer/Token prefixes from authentication tokens before saving them in the session
- reuse the normalized token when guessing expiration and persisting NK and True API credentials

## Testing
- php -l config/app.php
- php -l src/OrderAuth.php

------
https://chatgpt.com/codex/tasks/task_e_68da4e3f89a4832084bf34e10d7b97ae