### PR TITLE
Refine OMS connection settings UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,12 @@
             margin-bottom: 2rem;
             font-size: 0.95rem;
         }
+
+        .toolbar {
+            display: flex;
+            justify-content: flex-end;
+            margin-bottom: 1.5rem;
+        }
         
         .step {
             border: 2px solid #e2e8f0;
@@ -358,42 +364,16 @@
             <p class="summary-note" id="certSummary">Сертификат: не выбран</p>
         </div>
 
-        <div class="btn-group">
-            <button class="btn btn-primary" id="openSettingsBtn" type="button">Открыть настройки авторизации</button>
+        <div class="toolbar">
+            <button class="btn btn-primary" id="openSettingsBtn" type="button">Настройки соединения</button>
         </div>
 
-    <h2>Шаг 1: Авторизация</h2>
-    
-    <div class="status" id="nkStatus">
-        <span>🔴</span>
-        <span>Токен НК: не получен</span>
+        <p class="hint" style="margin-bottom: 0;">
+            Для управления сертификатами, получения токенов и сохранения настроек OMS откройте окно
+            «Настройки соединения».
+        </p>
     </div>
-    
-    <div class="status" id="suzStatus">
-        <span>🔴</span>
-        <span>Токен СУЗ: не получен</span>
-    </div>
-    
-    <div class="status" id="omsStatus">
-        <span>🔴</span>
-        <span>OMS настройки: не сохранены</span>
-    </div>
-    
-    <div class="form-group">
-        <label>Сертификат УКЭП</label>
-        <select id="certSelect" disabled>
-            <option>Загрузите сертификаты...</option>
-        </select>
-    </div>
-    
-    <div class="btn-group">
-        <button class="btn btn-secondary" id="loadCertsBtn">Обновить сертификаты</button>
-        <button class="btn btn-secondary" id="openSettingsBtn">Настройки OMS</button>
-        <button class="btn btn-primary" id="authNkBtn" disabled>Получить токен НК</button>
-        <button class="btn btn-primary" id="authSuzBtn" disabled>Получить токен СУЗ</button>
 
-    </div>
-    
     <!-- Шаг 2: Карточка -->
     <div class="step">
         <h2>Шаг 2: Найти карточку товара</h2>
@@ -551,7 +531,6 @@
 <div class="modal-backdrop" id="settingsModal" aria-hidden="true">
     <div class="modal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
         <div class="modal-header">
-
             <h2 id="settingsTitle">Авторизация и настройки OMS</h2>
             <button class="modal-close" id="closeSettingsBtn" aria-label="Закрыть">×</button>
         </div>
@@ -575,7 +554,7 @@
             <div class="modal-section">
                 <h3>Сертификат и токены</h3>
                 <div class="form-group">
-                    <label>Сертификат УКЭП</label>
+                    <label for="certSelect">Сертификат УКЭП</label>
                     <select id="certSelect" disabled>
                         <option>Загрузите сертификаты...</option>
                     </select>
@@ -598,20 +577,6 @@
                     <label for="omsId">OMS ID (UUID идентификатор)</label>
                     <input type="text" id="omsId" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" autocomplete="off">
                 </div>
-
-            <h2 id="settingsTitle">Настройки OMS</h2>
-            <button class="modal-close" id="closeSettingsBtn" aria-label="Закрыть">×</button>
-        </div>
-        <div class="modal-body">
-            <div class="form-group">
-                <label for="omsConnection">Идентификатор соединения</label>
-                <input type="text" id="omsConnection" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" autocomplete="off">
-                <p class="hint">Используйте GUID из личного кабинета ОМС.</p>
-            </div>
-            <div class="form-group">
-                <label for="omsId">OMS ID (UUID идентификатор)</label>
-                <input type="text" id="omsId" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" autocomplete="off">
-
             </div>
         </div>
         <div class="modal-actions">
@@ -701,18 +666,6 @@ function updateStatus() {
 
     const omsStatus = $('omsStatus');
 
-    $('nkStatus').className = 'status ' + (state.nkActive ? 'active' : 'inactive');
-    $('nkStatus').innerHTML = state.nkActive
-        ? '<span>✅</span><span>Токен НК: активен</span>'
-        : '<span>🔴</span><span>Токен НК: не получен</span>';
-    
-    $('suzStatus').className = 'status ' + (state.suzActive ? 'active' : 'inactive');
-    $('suzStatus').innerHTML = state.suzActive
-        ? '<span>✅</span><span>Токен СУЗ: активен</span>'
-        : '<span>🔴</span><span>Токен СУЗ: не получен</span>';
-
-    $('omsStatus').className = 'status ' + (state.omsSaved ? 'active' : 'inactive');
-
     const shortConnection = state.omsConnection
         ? `${state.omsConnection.slice(0, 8)}…${state.omsConnection.slice(-4)}`
         : '';
@@ -761,10 +714,6 @@ function updateStatus() {
             certSummary.textContent = 'Сертификат: не выбран';
         }
     }
-
-    $('omsStatus').innerHTML = state.omsSaved
-        ? `<span>✅</span><span>${omsDescription}</span>`
-        : '<span>🔴</span><span>OMS настройки: не сохранены</span>';
 
 
     const canOrder = state.nkActive && state.suzActive && state.omsSaved && state.card;


### PR DESCRIPTION
## Summary
- move the OMS controls into the modal and expose them through a single "Настройки соединения" trigger
- tidy the modal layout so certificate selection and OMS fields live in one place with a proper dropdown
- clean up the status updater logic to work with the unified modal elements

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e398dda8a8832096a4f21497239892